### PR TITLE
Add placeholder pages for auth, settings, and help

### DIFF
--- a/src/pages/Auth/ForgotPassword.jsx
+++ b/src/pages/Auth/ForgotPassword.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function ForgotPassword() {
+  return <div>Forgot Password</div>;
+}
+
+export default ForgotPassword;

--- a/src/pages/Auth/Login.jsx
+++ b/src/pages/Auth/Login.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Login() {
+  return <div>Login</div>;
+}
+
+export default Login;

--- a/src/pages/Auth/Register.jsx
+++ b/src/pages/Auth/Register.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Register() {
+  return <div>Register</div>;
+}
+
+export default Register;

--- a/src/pages/Help/Help.jsx
+++ b/src/pages/Help/Help.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Help() {
+  return <div>Help</div>;
+}
+
+export default Help;

--- a/src/pages/Settings/Settings.jsx
+++ b/src/pages/Settings/Settings.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+function Settings() {
+  return <div>Settings</div>;
+}
+
+export default Settings;


### PR DESCRIPTION
## Summary
- add basic login, register and forgot password pages under `pages/Auth`
- add placeholder pages for settings and help sections
- ensure `App.jsx` imports the new paths

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867b7a2ef388322aa2b69770aa53be5