### PR TITLE
Fix reporting icon mismatch

### DIFF
--- a/src/components/Layout/Sidebar.jsx
+++ b/src/components/Layout/Sidebar.jsx
@@ -8,7 +8,7 @@ import * as FiIcons from 'react-icons/fi';
 
 const {
   FiHome, FiUsers, FiPackage, FiCreditCard, FiFileText, FiDollarSign,
-  FiFolderPlus, FiCheckSquare, FiClock, FiBell, FiShield, FiBarChart3,
+  FiFolderPlus, FiCheckSquare, FiClock, FiBell, FiShield, FiBarChart2,
   FiUserCheck, FiSettings, FiHelpCircle, FiZap, FiChevronLeft,
   FiChevronRight, FiPin, FiPinOff
 } = FiIcons;
@@ -100,7 +100,7 @@ const menuItems = [
   {
     id: 'reporting',
     label: 'Reporting',
-    icon: FiBarChart3,
+    icon: FiBarChart2,
     path: '/reporting',
     roles: ['ADMIN', 'CLIENT']
   },


### PR DESCRIPTION
## Summary
- use `FiBarChart2` for the Reporting menu item

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867b7a4d44083229d32b57a00e85830