### PR TITLE
Add setup README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Digital Agency CRM Platform Blueprint
+
+This project contains a React-based CRM application built with Vite.
+
+## Setup
+
+Install the development and runtime dependencies using either `npm install` or `npm ci`:
+
+```bash
+npm install
+# or
+npm ci
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+Linting (`npm run lint`) and building (`npm run build`) require the above dependencies, such as `@eslint/js`, to be installed.


### PR DESCRIPTION
## Summary
- document how to set up and run the app in a new README

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6867b7a5c3d883229aad03d6e71c0d0b